### PR TITLE
Changing logger config to relative path

### DIFF
--- a/Lablup/benchmarks/maskrcnn/implementations/pytorch/maskrcnn_benchmark/utils/mlperf_logger.py
+++ b/Lablup/benchmarks/maskrcnn/implementations/pytorch/maskrcnn_benchmark/utils/mlperf_logger.py
@@ -52,7 +52,7 @@ def _log_print(logger, *args, **kwargs):
 
 
 def configure_logger(benchmark):
-    mllog.config(filename=os.path.join(os.path.dirname(os.path.abspath(__file__)), f'{benchmark}.log'))
+    mllog.config(filename=os.path.join(os.path.dirname(os.path.abspath(__file__)), f'.{benchmark}.log'))
     mllogger = mllog.get_mllogger()
     mllogger.logger.propagate = False
 


### PR DESCRIPTION
Changing to relative path since we don't use Docker directly. Otherwise, we would bump into a permission error when it will try to access logger files.