### PR TITLE
Update paths for backend.ai specific paths

### DIFF
--- a/Lablup/benchmarks/maskrcnn/implementations/pytorch/maskrcnn_benchmark/config/paths_catalog.py
+++ b/Lablup/benchmarks/maskrcnn/implementations/pytorch/maskrcnn_benchmark/config/paths_catalog.py
@@ -5,7 +5,8 @@ import os
 
 
 class DatasetCatalog(object):
-    DATA_DIR = "datasets"
+    DATA_DIR_TEMP = "../../home/work/mlperf-data/pytorch/datasets"
+    DATA_DIR = os.path.abspath(os.path.join(DATA_DIR_TEMP))
     DATASETS = {
         "coco_2017_train": {
             "img_dir": "coco/train2017",


### PR DESCRIPTION
Modifying the paths for the datasets to reflect that we use datasets from our own `mlperf-data` folder.